### PR TITLE
Less JS more wasm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,16 @@
 #!/usr/bin/env node
 const { main } = require('./pkg/cenv_wasm.js');
 
-const logErrorAndExit = (err, description = "Failed with the following error:") => {
+const logErrorAndExit = (err) => {
   console.log("\x1b[31m%s\x1b[0m", "[Error] - Error while running");
-  console.log("\x1b[31m%s\x1b[0m", " |", description);
+  console.log("\x1b[31m%s\x1b[0m", " |", "Failed with the following error:");
   console.log("\x1b[31m%s\x1b[0m", " |", err);
   process.exit(1);
 };
 
-const jsMain = () => {
-  const providedKeyword = process.argv[2];
-
-  if (!providedKeyword) {
-    logErrorAndExit("e.g. `cenv myKeyword`", "Please provide your keyword as the first argument to cenv");
-    return;
-  }
-
-  let newEnv;
-  try {
-    newEnv = main(providedKeyword)
-  } catch (err) {
-    logErrorAndExit(err);
-    return;
-  }
-
+try {
+  newEnv = main()
   process.exit(0);
+} catch (err) {
+  logErrorAndExit(err);
 }
-
-jsMain();

--- a/index.js
+++ b/index.js
@@ -1,42 +1,30 @@
 #!/usr/bin/env node
-const { readFile, writeFile } = require('fs/promises');
-const { parse_env } = require('./pkg/cenv_wasm.js');
+const { main } = require('./pkg/cenv_wasm.js');
 
-const FILE = '.env';
-
-const logFsErrorAndExit = (err) => {
-  console.log("\x1b[31m%s\x1b[0m", "[Error] - Error while reading", FILE, "file");
-  console.log("\x1b[31m%s\x1b[0m", " |", "Failed with the following error:");
-  console.log("\x1b[31m%s\x1b[0m", " |", err.message);
+const logErrorAndExit = (err, description = "Failed with the following error:") => {
+  console.log("\x1b[31m%s\x1b[0m", "[Error] - Error while running");
+  console.log("\x1b[31m%s\x1b[0m", " |", description);
+  console.log("\x1b[31m%s\x1b[0m", " |", err);
   process.exit(1);
 };
 
-const main = async () => {
-  const currentEnv = await readFile(FILE, { encoding: 'utf-8' }).catch(logFsErrorAndExit)
-
+const jsMain = async () => {
   const providedKeyword = process.argv[2];
 
   if (!providedKeyword) {
-    console.log("\x1b[31m%s\x1b[0m", "[Error] - No keyword provided");
-    console.log("\x1b[31m%s\x1b[0m", " |", "Please provide your keyword as the first argument to cenv");
-    console.log("\x1b[31m%s\x1b[0m", " |", "e.g. `cenv myKeyword`");
-    process.exit(1);
+    logErrorAndExit("e.g. `cenv myKeyword`", "Please provide your keyword as the first argument to cenv");
+    return;
   }
 
   let newEnv;
   try {
-    newEnv = parse_env(currentEnv, providedKeyword)
+    newEnv = main(providedKeyword)
   } catch (err) {
-    console.log("\x1b[31m%s\x1b[0m", "[Error] - Error while running");
-    console.log("\x1b[31m%s\x1b[0m", " |", "Failed with the following error:");
-    console.log("\x1b[31m%s\x1b[0m", " |", err);
-    process.exit(1);
+    logErrorAndExit(err);
+    return;
   }
 
-  await writeFile(FILE, newEnv).catch(logFsErrorAndExit)
-
-  console.log("Updated", FILE, "to", providedKeyword);
   process.exit(0);
 }
 
-main();
+jsMain();

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const logErrorAndExit = (err, description = "Failed with the following error:") 
   process.exit(1);
 };
 
-const jsMain = async () => {
+const jsMain = () => {
   const providedKeyword = process.argv[2];
 
   if (!providedKeyword) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "files": [
     "index.js",
     "pkg/cenv_wasm_bg.wasm",
-    "pkg/cenv_wasm.js"
+    "pkg/cenv_wasm.js",
+    "pkg/snippets/*"
   ],
   "repository": {
     "type": "git",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,15 @@ pub fn parse_env(env: &EnvContents, config: &Config) -> Result<EnvContents, Stri
 }
 
 #[wasm_bindgen]
-pub fn main(keyword: &str) -> Result<(), JsValue> {
-    let config = match Config::new(keyword) {
+pub fn main() -> Result<(), JsValue> {
+    let keyword = match utils::get_keyword() {
+        Ok(k) => k,
+        Err(e) => {
+            return Err(JsValue::from(e));
+        }
+    };
+
+    let config = match Config::new(&keyword) {
         Ok(c) => c,
         Err(e) => {
             return Err(JsValue::from(e));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,66 +2,81 @@ use wasm_bindgen::prelude::*;
 
 #[derive(PartialEq)]
 pub enum ParseStatus {
-  Active,
-  Inactive,
-  Ignore,
+    Active,
+    Inactive,
+    Ignore,
 }
 
 #[derive(PartialEq, Debug)]
 pub struct Config {
-  pub keyword: String,
+    pub keyword: String,
 }
 
 impl Config {
-  pub fn new(keyword: &str) -> Result<Config, &'static str> {
-    let keyword = match keyword {
-      "" => return Err("Keyword missing"),
-      word => word,
-    };
+    pub fn new(keyword: &str) -> Result<Config, &'static str> {
+        let keyword = match keyword {
+            "" => return Err("Keyword missing"),
+            word => word,
+        };
 
-    Ok(Config {
-      keyword: String::from(keyword),
-    })
-  }
+        Ok(Config {
+            keyword: String::from(keyword),
+        })
+    }
 }
 
 #[derive(PartialEq, Debug)]
 pub struct EnvContents {
-  pub contents: String,
+    pub contents: String,
 }
 
 impl EnvContents {
-  pub fn new(contents: String) -> EnvContents {
-    EnvContents { contents }
-  }
+    pub fn new(contents: String) -> EnvContents {
+        EnvContents { contents }
+    }
 }
 
 #[wasm_bindgen(module = "fs")]
 extern "C" {
-  #[wasm_bindgen(js_name = readFileSync, catch)]
-  fn read_file_sync(path: &str, format: &str) -> Result<String, JsValue>;
+    #[wasm_bindgen(js_name = readFileSync, catch)]
+    fn read_file_sync(path: &str, format: &str) -> Result<String, JsValue>;
 
-  #[wasm_bindgen(js_name = writeFileSync, catch)]
-  fn write_file_sync(path: &str, data: &str) -> Result<(), JsValue>;
+    #[wasm_bindgen(js_name = writeFileSync, catch)]
+    fn write_file_sync(path: &str, data: &str) -> Result<(), JsValue>;
 }
 
 #[wasm_bindgen]
 extern "C" {
-  #[wasm_bindgen(js_namespace = console)]
-  pub fn log(s: &str);
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(s: &str);
 }
 
 pub fn read_env_file() -> Result<EnvContents, &'static str> {
-  let contents = match read_file_sync(".env", "utf-8") {
-    Ok(w) => w,
-    Err(_) => return Err("Unable to read .env file"),
-  };
-  Ok(EnvContents { contents })
+    let contents = match read_file_sync(".env", "utf-8") {
+        Ok(w) => w,
+        Err(_) => return Err("Unable to read .env file"),
+    };
+    Ok(EnvContents { contents })
 }
 
-pub fn write_to_file(env: &EnvContents) -> Result<(), String> {
-  match write_file_sync(".env", &env.contents) {
-    Ok(_) => Ok(()),
-    Err(_) => Err(String::from("Unable to write .env file")),
-  }
+pub fn write_to_file(env: &EnvContents) -> Result<(), &'static str> {
+    match write_file_sync(".env", &env.contents) {
+        Ok(_) => Ok(()),
+        Err(_) => Err("Unable to write .env file"),
+    }
+}
+
+// FYI - For anything more complex this would be a module #[wasm_bindgen(module = "/js/foo.js")]
+#[wasm_bindgen(inline_js = "module.exports = { get_arg: () => process.argv[2]}")]
+extern "C" {
+    fn get_arg() -> Option<String>;
+}
+
+pub fn get_keyword() -> Result<String, &'static str> {
+    match get_arg() {
+        Some(k) => Ok(k),
+        None => {
+            Err("Please provide your keyword as the first argument to cenv, e.g. `cenv myKeyword`")
+        }
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,67 @@
+use wasm_bindgen::prelude::*;
+
 #[derive(PartialEq)]
 pub enum ParseStatus {
   Active,
   Inactive,
   Ignore,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Config {
+  pub keyword: String,
+}
+
+impl Config {
+  pub fn new(keyword: &str) -> Result<Config, &'static str> {
+    let keyword = match keyword {
+      "" => return Err("Keyword missing"),
+      word => word,
+    };
+
+    Ok(Config {
+      keyword: String::from(keyword),
+    })
+  }
+}
+
+#[derive(PartialEq, Debug)]
+pub struct EnvContents {
+  pub contents: String,
+}
+
+impl EnvContents {
+  pub fn new(contents: String) -> EnvContents {
+    EnvContents { contents }
+  }
+}
+
+#[wasm_bindgen(module = "fs")]
+extern "C" {
+  #[wasm_bindgen(js_name = readFileSync, catch)]
+  fn read_file_sync(path: &str, format: &str) -> Result<String, JsValue>;
+
+  #[wasm_bindgen(js_name = writeFileSync, catch)]
+  fn write_file_sync(path: &str, data: &str) -> Result<(), JsValue>;
+}
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(js_namespace = console)]
+  pub fn log(s: &str);
+}
+
+pub fn read_env_file() -> Result<EnvContents, &'static str> {
+  let contents = match read_file_sync(".env", "utf-8") {
+    Ok(w) => w,
+    Err(_) => return Err("Unable to read .env file"),
+  };
+  Ok(EnvContents { contents })
+}
+
+pub fn write_to_file(env: &EnvContents) -> Result<(), String> {
+  match write_file_sync(".env", &env.contents) {
+    Ok(_) => Ok(()),
+    Err(_) => Err(String::from("Unable to write .env file")),
+  }
 }


### PR DESCRIPTION
Added JS bindings for reading / writing the file (see utils file).

This means we don't have to manually do the I/O in JS then send the results over to rust, we can use the function as if it were native.

A key benefit of this is that I can re-use more of the architecture from the rust-only project https://github.com/JonShort/cenv.

Did some benchmarking to see if this work was worth it performance-wise:

| method             | time    |
| --------------- | ------ |
| wasm (original)| 0.27s |
| wasm (new)| 0.29s |
| pure rust (https://github.com/JonShort/cenv)| 0.00s |

I guess the pure rust is too fast for the `time` command 😅 cpu-wise it sits around `0.010 total`