### PR TITLE
List available keywords when user provides an invalid keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Available keywords are now listed to the user when invalid or no keyword provided
+
+## [0.0.5] - 2021-06-19
+### Changed
+- Performance improvements, now using [cenv_core](https://crates.io/crates/cenv_core) internals
+
+## 0.0.4 - 2021-05-18
+### Changed
+-  Performance improvements, more work performed via. wasm
+
+## 0.0.3 - 2021-05-12
+### Added
+- Alert and exit if keyword doesn't exist within file
+
+## 0.0.2 - 2021-05-11
+### Added
+- MVP functionality
+
+[Unreleased]: https://github.com/JonShort/cenv-wasm/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/JonShort/cenv-wasm/releases/tag/v0.0.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-cenv_core = "0.1.0"
+cenv_core = "0.2"
 
 wee_alloc = { version = "0.4.2", optional = true }
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 const { main } = require('./pkg/cenv_wasm.js');
 
-const logErrorAndExit = (err) => {
+const logErrorAndExit = (err = "") => {
+  const msgs = err.split('|');
+
   console.log("\x1b[31m%s\x1b[0m", "[Error] - Error while running");
   console.log("\x1b[31m%s\x1b[0m", " |", "Failed with the following error:");
-  console.log("\x1b[31m%s\x1b[0m", " |", err);
+  msgs.forEach(msg => console.log("\x1b[31m%s\x1b[0m", " |", msg));
+
   process.exit(1);
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,27 @@
 use wasm_bindgen::prelude::*;
 mod utils;
-use cenv_core::{parse_env, Config};
+use cenv_core::{list_available_keywords, parse_env, Config, EnvContents};
+
+fn add_keywords_to_error(env: &EnvContents, err: &str) -> String {
+    let keys = list_available_keywords(env);
+    let keys = keys.join("| - ");
+
+    format!("{}||Available keywords:| - {}", err, keys)
+}
 
 #[wasm_bindgen]
 pub fn main() -> Result<(), JsValue> {
+    let env = match utils::read_env_file() {
+        Ok(d) => d,
+        Err(e) => {
+            return Err(JsValue::from(e));
+        }
+    };
+
     let keyword = match utils::get_keyword() {
         Ok(k) => k,
         Err(e) => {
+            let e = add_keywords_to_error(&env, e);
             return Err(JsValue::from(e));
         }
     };
@@ -17,16 +32,11 @@ pub fn main() -> Result<(), JsValue> {
             return Err(JsValue::from(e));
         }
     };
-    let env = match utils::read_env_file() {
-        Ok(d) => d,
-        Err(e) => {
-            return Err(JsValue::from(e));
-        }
-    };
 
     let new_env = match parse_env(&env, &config) {
         Ok(env) => env,
         Err(e) => {
+            let e = add_keywords_to_error(&env, &e);
             return Err(JsValue::from(e));
         }
     };


### PR DESCRIPTION
This PR adds a new feature where users providing an invalid keyword will be presented with a list of keywords that are available within the`.env` file in scope.

![image](https://user-images.githubusercontent.com/21317379/127979315-907305c4-3aba-432b-9c58-1fb209031706.png)

Built using the functionality added to [cenv_core](https://crates.io/crates/cenv_core) as part of https://github.com/JonShort/cenv/pull/6