### PR TITLE
Get latest features from cenv_core

### DIFF
--- a/.example
+++ b/.example
@@ -4,8 +4,16 @@ TEST_B=1
 
 # ++ two ++
 # TEST_A=2
+# this controls something
 # TEST_B=2
 
 # ++ three ++
+# this is a var
 # TEST_A=3
-# TEST_B=3
+
+# ++ one ++
+TEST_C=3
+# ++ two ++
+# TEST_C=3
+# ++ three ++
+# TEST_C=3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated internals to target rust 2021
+- Comments are now valid within "cenv" blocks and will be ignored
+- The keywords listed when an invalid choice is made are now de-deuplicated
 
 ## [0.0.6] - 2021-08-03
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-cenv_core = "0.2"
+cenv_core = "0.3"
 
 wee_alloc = { version = "0.4.5", optional = true }
 


### PR DESCRIPTION
## Changes
- Bump cenv_core to `0.3`
- Improve example file

## New features
- Deduplicated keywords ([example](https://github.com/JonShort/cenv/pull/8))
- Comment support within cenv blocks ([example](https://github.com/JonShort/cenv/pull/7))